### PR TITLE
Mistakes in calculating spatial information

### DIFF
--- a/+analyses/mapStatsPDF.m
+++ b/+analyses/mapStatsPDF.m
@@ -41,7 +41,7 @@ function [information, sparsity, selectivity] = mapStatsPDF(map)
     else
        selectivity = maxrate / meanrate;
        logArg = map.z / meanrate;
-       logArg(logArg < 1) = 1;
+       logArg(logArg == 0) = 1;
        
        information.rate = nansum(nansum(posPDF .* map.z .* log2(logArg)));
        information.content = information.rate / meanrate;


### PR DESCRIPTION
Mistakes in calculating spatial information rate and content, in Line 44
Original: 
       logArg(logArg < 1) = 1;
Corrected: 
       logArg(logArg == 0) = 1;

Original implementation will over-estimate the spatial information given the rate map.